### PR TITLE
#2 API関数の追加

### DIFF
--- a/src/lib/api/expenses.ts
+++ b/src/lib/api/expenses.ts
@@ -1,6 +1,31 @@
-import { GetExpensesResponse } from "@/lib/types/expense";
+import { CreateExpenseInput, Expense, GetExpensesResponse } from "@/lib/types/expense";
 
 const API_BASE_URL = "http://localhost:8080";
+
+export async function createExpense(
+  input: CreateExpenseInput
+): Promise<Expense> {
+  const res = await fetch(`${API_BASE_URL}/expenses`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(input),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Failed to create expense: ${res.status} ${text}`)
+  }
+
+  const data = await res.json()
+  if (!data || !data.expense) {
+    throw new Error(`Invalid createExpense response: ${JSON.stringify(data)}`)
+  }
+
+  return data.expense
+}
+
 
 export async function getExpenses(): Promise<GetExpensesResponse> {
   const res = await fetch(`${API_BASE_URL}/expenses`, {
@@ -11,5 +36,10 @@ export async function getExpenses(): Promise<GetExpensesResponse> {
     throw new Error("Failed to fetch expenses");
   }
 
-  return res.json();
+  const data = await res.json();
+  if (!data || !Array.isArray(data.expenses)) {
+    throw new Error(`Invalid getExpenses response: ${JSON.stringify(data)}`)
+  }
+
+  return data;
 }

--- a/src/lib/api/expenses.ts
+++ b/src/lib/api/expenses.ts
@@ -1,0 +1,15 @@
+import { GetExpensesResponse } from "@/lib/types/expense";
+
+const API_BASE_URL = "http://localhost:8080";
+
+export async function getExpenses(): Promise<GetExpensesResponse> {
+  const res = await fetch(`${API_BASE_URL}/expenses`, {
+    method: "GET",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch expenses");
+  }
+
+  return res.json();
+}

--- a/src/lib/types/expense.ts
+++ b/src/lib/types/expense.ts
@@ -1,11 +1,18 @@
+export type CreateExpenseInput = {
+    amount: number
+    category_id: number
+    memo?: string
+    spent_at: string // yyyy-mm-dd
+}
+
 export type Expense = {
-  id: number;
-  amount: number;
-  category_id: number;
-  memo: string | null;
-  spent_at: string; // YYYY-MM-DD
+    id: number;
+    amount: number;
+    category_id: number;
+    memo: string | null;
+    spent_at: string; // YYYY-MM-DD
 };
 
 export type GetExpensesResponse = {
-  expenses: Expense[];
+    expenses: Expense[];
 };

--- a/src/lib/types/expense.ts
+++ b/src/lib/types/expense.ts
@@ -1,0 +1,11 @@
+export type Expense = {
+  id: number;
+  amount: number;
+  category_id: number;
+  memo: string | null;
+  spent_at: string; // YYYY-MM-DD
+};
+
+export type GetExpensesResponse = {
+  expenses: Expense[];
+};


### PR DESCRIPTION
- closes: nt624/money-buddy#9 
**概要**
- `createExpense` を含む支出API呼び出しをフロントから簡易検証できるように、page.tsx にクイックな呼び出しを追加。
- 今後の単体テストに向けて `vitest` と `jsdom` を `devDependencies` に追加。

**変更内容**
- page.tsx:
  - `"use client"` を追加しクライアントコンポーネント化。
  - `getExpenses()` を `useEffect` 内で呼び出して結果を `console.log` に出力。
  - `createExpense()` を別の `useEffect` で呼び出して結果を `console.log` に出力（固定のサンプルデータをPOST）。
  - 補足: `domain` からの `create`、`React` の `use` など未使用インポートがあります。後続で削除を検討。
- package.json / package-lock.json:
  - `devDependencies` に `vitest`、`jsdom` を追加（ロックファイルに関連依存が反映）。

**目的**
- 追加したAPI関数（特に POST の `createExpense`）をフロントから手早く検証するための足場を用意。
- テストフレームワークの導入により、今後APIやUIの単体テストを追加しやすくする。

**動作確認手順**
- 依存関係のインストール:
```bash
npm install
```
- 開発サーバー起動:
```bash
npm run dev
```
- バックエンドのAPIが `http://localhost:8080` で起動していることを確認。
- ブラウザで `http://localhost:3000` を開き、DevToolsのコンソールを確認:
  - `getExpenses()` のレスポンスが出力されること
  - `createExpense()` のレスポンスが出力されること（実際にレコードが1件作成されます）

**注意点**
- `createExpense` は実データを作成します。不要であれば該当 `useEffect` をコメントアウトするか、モック・環境変数で制御してください。
- `API_BASE_URL` は現状 `http://localhost:8080` でハードコードされています。必要に応じて `NEXT_PUBLIC_API_BASE_URL` などの環境変数に置き換えることを検討ください。
- 未使用インポート（`domain` の `create`、`React` の `use`）が残っています。別PRまたはこのPRで削除可能です。

**テスト（将来）**
- Vitestでテストを実行する場合（テスト追加後）:
```bash
npx vitest
```