### PR TITLE
#6 状態管理を追加

### DIFF
--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -1,12 +1,33 @@
-import { useState } from "react";
-import { createExpense } from "@/lib/api/expenses";
+import { useEffect, useState } from "react";
+import { createExpense, getExpenses } from "@/lib/api/expenses";
 import { CreateExpenseInput, Expense } from "@/lib/types/expense";
 
 export function useExpenses() {
     const [expenses, setExpenses] = useState<Expense[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
+    // GET
+    useEffect(() => {
+        const fetchExpenses = async () => {
+            setIsLoading(true);
+            setError(null);
+
+            try {
+                const data = await getExpenses();
+                setExpenses(data.expenses);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'unknown error');
+            } finally {
+                setIsLoading(false);
+            }
+        }
+
+        fetchExpenses();
+    }, []);
+
+    // POST
     const addExpense = async (input: CreateExpenseInput) => {
         setIsSubmitting(true);
         setError(null);
@@ -23,6 +44,7 @@ export function useExpenses() {
 
     return {
         expenses,
+        isLoading,
         isSubmitting,
         error,
         addExpense,

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { createExpense } from "@/lib/api/expenses";
+import { CreateExpenseInput, Expense } from "@/lib/types/expense";
+
+export function useExpenses() {
+    const [expenses, setExpenses] = useState<Expense[]>([]);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const addExpense = async (input: CreateExpenseInput) => {
+        setIsSubmitting(true);
+        setError(null);
+
+        try {
+            const expense = await createExpense(input);
+            setExpenses((prevExpenses) => [...prevExpenses, expense]);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'unknown error');
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return {
+        expenses,
+        isSubmitting,
+        error,
+        addExpense,
+    }
+}


### PR DESCRIPTION
## 概要
- **目的:** `useExpenses`フックで支出取得・作成の状態管理を共通化。
- **背景:** page.tsxの`isLoading`参照時の型エラーを解消。

## 変更点
- **フック:** useExpenses.tsに`useExpenses`を追加。
- **状態管理:** `expenses`/`isLoading`/`isSubmitting`/`error`を管理。
- **API連携:** 初回マウントで`getExpenses`、`addExpense`で`createExpense`を呼び出し成功時に`expenses`へ反映。
- **戻り値:** `{ expenses, isLoading, isSubmitting, error, addExpense }` を返却しpage.tsxの`isLoading`が利用可能に。

## 動作確認
- **ローディング:** 初回レンダリング時に`isLoading`が`true`で「読み込み中…」表示。
- **送信中:** 追加ボタンは`isSubmitting`中に無効化、ラベルが「送信中…」に切替。
- **一覧更新:** `addExpense`成功後に新規支出が`expenses`に追加される。
- **エラー表示:** 失敗時は`error`にメッセージが入りUIで表示。
- **型検査:** TypeScript診断でエラーなしを確認。

## 影響範囲
- **利用箇所:** page.tsxで`useExpenses`を使用。
- **後方互換:** 戻り値の追加のみで破壊的変更なし。

## 関連
- closes: nt624/money-buddy#7 （CreateExpenseの状態管理追加）
- **ブランチ:** `issue-6-add-state`