### PR TITLE
#11 カテゴリーのAPI対応

### DIFF
--- a/src/components/ExpenseForm.tsx
+++ b/src/components/ExpenseForm.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import styles from './ExpenseForm.module.css'
 import { CreateExpenseInput } from '@/lib/types/expense'
+import { getCategories } from '@/lib/api/categories'
+import { Category } from '@/lib/types/category'
 
 type Props = {
     onSubmit: (input: CreateExpenseInput) => Promise<void>
@@ -14,6 +16,13 @@ export function ExpenseForm({ onSubmit, isSubmitting }: Props) {
     const [categoryId, setCategoryId] = useState('1')
     const [memo, setMemo] = useState('')
     const [spentAt, setSpentAt] = useState('')
+    const [categories, setCategories] = useState<Category[]>([])
+
+    useEffect(() => {
+        getCategories()
+            .then(setCategories)
+            .catch(console.error)
+    }, [])
 
     const [errors, setErrors] = useState<{
         amount?: string
@@ -35,7 +44,6 @@ export function ExpenseForm({ onSubmit, isSubmitting }: Props) {
         setErrors(newErrors)
         return Object.keys(newErrors).length === 0
     }
-
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
@@ -59,7 +67,6 @@ export function ExpenseForm({ onSubmit, isSubmitting }: Props) {
 
     return (
         <form onSubmit={handleSubmit} className={styles.form}>
-            {/* Each field stack: label + control. Minimal classes to protect layout */}
             <div className={styles.field}>
                 <label className={styles.label}>
                     金額
@@ -77,13 +84,15 @@ export function ExpenseForm({ onSubmit, isSubmitting }: Props) {
                 <label className={styles.label}>
                     カテゴリ
                     <select
-                        className={styles.input}
                         value={categoryId}
                         onChange={(e) => setCategoryId(e.target.value)}
                     >
-                        <option value="1">食費</option>
-                        <option value="2">日用品</option>
-                        <option value="3">交通費</option>
+                        <option value="">カテゴリを選択</option>
+                        {categories.map((category) => (
+                            <option key={category.id} value={category.id}>
+                                {category.name}
+                            </option>
+                        ))}
                     </select>
                 </label>
             </div>

--- a/src/lib/api/categories.ts
+++ b/src/lib/api/categories.ts
@@ -1,0 +1,12 @@
+import { Category } from "@/lib/types/category";
+
+export async function getCategories(): Promise<Category[]> {
+  const res = await fetch("http://localhost:8080/categories")
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch categories")
+  }
+
+  const data = await res.json()
+  return data.categories
+}

--- a/src/lib/types/category.ts
+++ b/src/lib/types/category.ts
@@ -1,0 +1,4 @@
+export type Category = {
+  id: number
+  name: string
+}


### PR DESCRIPTION
**概要**
- カテゴリーAPIの追加と型定義を導入し、フォームでカテゴリ一覧を取得・選択できるように対応。
- `ExpenseForm` のフックをコンポーネント内へ移動し、React Hooksのルール違反によるエラーを解消。

**変更点**
- categories.ts: **API**: `getCategories` を追加（カテゴリ一覧を取得）。
- category.ts: **型**: `Category` 型を追加（`id`, `name`）。
- ExpenseForm.tsx: 
  - **フック配置**: `useState`/`useEffect` を関数コンポーネント内へ移動。
  - **カテゴリ取得**: マウント時に `getCategories` を実行し、`select` に一覧を表示。
  - **整理**: 重複した `use client` と import を削除。

**動作確認**
- **テスト**: 既存のJestテストは全て通過。
  - 実行例: `npm test --silent`
- **手動確認**:
  - `npm run dev` を起動し、フォームでカテゴリのプルダウンが表示されること。
  - 金額・日付のバリデーションが機能すること。
  - 送信後にフォームがリセットされること。

**影響範囲**
- フロントのフォーム機能（カテゴリ選択・表示）に限定。既存の費用登録API呼び出しへは非破壊。

**破壊的変更**
- なし

**関連Issue**
- Close nt624/money-buddy#5

**補足/今後の改善案**
- **カテゴリ未選択**: 送信時に空カテゴリを許容しないバリデーションの追加検討。
- **初期選択**: 取得した最初のカテゴリを初期選択にする挙動の検討。
- **ローディング/エラーハンドリング**: 取得中のUIや失敗時のメッセージ表示の追加。