### PR TITLE
#13 支出リスト表示を追加する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useExpenses } from '@/hooks/useExpenses'
 import { ExpenseForm } from '@/components/ExpenseForm'
+import { ExpenseList } from '@/components/ExpenseList'
 
 export default function Home() {
   const { expenses, addExpense, isSubmitting, isLoading, error } =
@@ -17,13 +18,7 @@ export default function Home() {
       {error && <p style={{ color: 'red' }}>{error}</p>}
 
       <h2>支出一覧</h2>
-      <ul>
-        {expenses.map((e) => (
-          <li key={e.id}>
-            {e.spent_at} / {e.amount}円
-          </li>
-        ))}
-      </ul>
+      <ExpenseList expenses={expenses} />
     </main>
   )
 }

--- a/src/components/ExpenseList.tsx
+++ b/src/components/ExpenseList.tsx
@@ -1,0 +1,20 @@
+import { Expense } from "@/lib/types/expense"
+
+type Props = {
+  expenses: Expense[]
+}
+
+export function ExpenseList({ expenses }: Props) {
+  return (
+    <ul>
+      {expenses.map((e) => (
+        <li key={e.id}>
+          <span>{e.spent_at}</span> / 
+          <span>¥{e.amount}</span> / 
+          <span>カテゴリID: {e.category_id}</span> / 
+          <span>{e.memo}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}


### PR DESCRIPTION
- closes: nt624/money-buddy#4 
**PR 概要**
- 目的: 支出一覧表示をコンポーネント化し、page.tsxから分離して見通しを改善
- 関連Issue: Close nt624/money-buddy#4

**変更点**
- ExpenseList.tsx を新規追加
  - `Expense[]` を受け取り、`spent_at` / `amount` / `category_id` / `memo` を一覧表示
- page.tsx を修正
  - 既存の手書きの `<ul>` 一覧を `ExpenseList` コンポーネントに置き換え
  - インポートに `ExpenseList` を追加

**動作確認**
- `useExpenses()` の `expenses` が取得・追加されることを前提に、一覧が `ExpenseList` 経由で表示されることを確認
- 追加フォーム (`ExpenseForm`) から支出を登録すると、一覧に即時反映されることを確認

**影響範囲**
- 表示ロジックがコンポーネントへ移動したため、page.tsx の保守性・再利用性が向上
- API呼び出し・状態管理には変更なし（`useExpenses` は従来通り使用）

**確認方法**
- 開発起動:
  ```
  npm install
  npm run dev
  ```
- ブラウザでトップページを開く
- 金額・カテゴリ・日付を入力して追加
- 「支出一覧」に追加した内容が表示されること

この内容でPR本文にします。必要ならスクリーンショット項目も追記します。