### PR TITLE
#15 リストにカテゴリ名称を表示する

### DIFF
--- a/src/components/ExpenseList.tsx
+++ b/src/components/ExpenseList.tsx
@@ -11,7 +11,7 @@ export function ExpenseList({ expenses }: Props) {
         <li key={e.id}>
           <span>{e.spent_at}</span> / 
           <span>¥{e.amount}</span> / 
-          <span>カテゴリID: {e.category_id}</span> / 
+          <span>カテゴリ: {e.category.name}</span> / 
           <span>{e.memo}</span>
         </li>
       ))}

--- a/src/lib/api/expenses.test.ts
+++ b/src/lib/api/expenses.test.ts
@@ -14,15 +14,15 @@ describe("createExpense", () => {
     const input: CreateExpenseInput = {
       amount: 1200,
       category_id: 3,
-      memo: "lunch",
+      memo: "通勤",
       spent_at: "2025-12-31",
     };
 
     const expectedExpense: Expense = {
       id: 1,
       amount: 1200,
-      category_id: 3,
-      memo: "lunch",
+      category: { id: 3, name: "交通費" },
+      memo: "通勤",
       spent_at: "2025-12-31",
     };
 

--- a/src/lib/types/expense.ts
+++ b/src/lib/types/expense.ts
@@ -8,9 +8,12 @@ export type CreateExpenseInput = {
 export type Expense = {
     id: number;
     amount: number;
-    category_id: number;
     memo: string | null;
     spent_at: string; // YYYY-MM-DD
+    category: {
+        id: number;
+        name: string;
+    }
 };
 
 export type GetExpensesResponse = {


### PR DESCRIPTION
- closes nt624/money-buddy#3 
**概要**
- 目的: 支出一覧でカテゴリ「ID」ではなく「名称」を表示する
- 背景: 既存データは名称表示できていたが、新規追加直後の一覧反映時にカテゴリ名が空欄になる問題があった
- 原因: `POST /expenses` のレスポンスに `category.name` が含まれていなかったため
- 対応: バックエンドで `category`（`id`, `name`）を含めて返すよう修正済み。フロントは型と表示を名称前提に統一
- 関連Issue: Close nt624/money-buddy#3

**主な変更**
- expense.ts
  - `Expense` を `category: { id: number; name: string }` を持つ形に更新
- ExpenseList.tsx
  - 表示を `カテゴリ: {e.category.name}` に変更（従来の `category_id` 表示を廃止）
- expenses.test.ts
  - `createExpense` 成功時のモックレスポンスを `category: { id, name }` 形式に更新
  - テストは `expense.category.name` を含むことを検証

**影響範囲・互換性**
- フロントの表示は `Expense.category.name` を前提に統一
- 取得・追加APIの呼び出し自体（`getExpenses`, `createExpense`）のIFは変更なし
- 既存の「一覧取得」も「新規追加直後の反映」も同一のデータ形（`category.name` あり）で整合

**動作確認**
- 新規追加（フォームから登録）後、一覧でカテゴリ名称が即時に表示されること
- 既存データも引き続きカテゴリ名称が表示されること
- ユニットテストが通ること

**確認手順**
```
npm install
npm test
npm run dev
```
- 画面で金額/カテゴリ/日付/メモを入力して追加
- 一覧の「カテゴリ」が名称で表示されることを確認

**補足（バックエンド仕様）**
- `POST /expenses` のレスポンス例
  - `{"expense": {"id": 1, "amount": 1200, "memo": "通勤", "spent_at": "2025-12-31", "category": {"id": 3, "name": "交通費"}}}`
- `GET /expenses` と同一構造（`category.name` を含む）で統一済み